### PR TITLE
Fix ResponseError

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    statuspageio (0.1.6)
+    statuspageio (0.2.0)
       httparty (~> 0.17)
 
 GEM
@@ -19,7 +19,7 @@ GEM
       multi_xml (>= 0.5.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
+    mime-types-data (3.2021.0901)
     multi_xml (0.6.0)
     parallel (1.20.1)
     parser (3.0.1.1)

--- a/lib/statuspageio/response_error.rb
+++ b/lib/statuspageio/response_error.rb
@@ -2,7 +2,7 @@
 
 module Statuspageio
   class ResponseError < StandardError
-    attr_reader :response, :code, :errors
+    attr_accessor :response, :code, :errors
 
     def initialize(res)
       self.response = res.response
@@ -15,7 +15,7 @@ module Statuspageio
     end
 
     def to_s
-      "#{code} #{response.msg}".strip
+      [code.to_s, response.msg, inlined_errors].compact.map(&:strip).join(' ')
     end
 
     private
@@ -31,6 +31,10 @@ module Statuspageio
       else
         []
       end
+    end
+
+    def inlined_errors
+      errors&.join(', ')
     end
   end
 end

--- a/lib/statuspageio/version.rb
+++ b/lib/statuspageio/version.rb
@@ -1,3 +1,3 @@
 module Statuspageio
-  VERSION = '0.1.6'
+  VERSION = '0.2.0'
 end

--- a/spec/incident_spec.rb
+++ b/spec/incident_spec.rb
@@ -243,6 +243,28 @@ describe Statuspageio::Client::Incident do
         expect { client.create_incident({ bad: 'options' }) }.to raise_error(ArgumentError)
       end
     end
+
+    context 'when error is returned by server' do
+      let(:body) { { error: 'incident is missing, incident[name] is missing' }.to_json }
+
+      before do
+        stub_request(:post, request_url).
+          with(body: options.to_json).
+          to_return(
+            headers: { 'Content-Type' => 'application/json' },
+            status: [400, 'Bad Request'],
+            body: body
+          )
+      end
+
+      it 'raises an error' do
+        expect { client.create_incident(options.merge(dog: 'cat')) }
+          .to raise_error do |error|
+            expect(error.class).to eq(Statuspageio::ResponseError)
+            expect(error.to_s).to eq('400 Bad Request error: incident is missing, incident[name] is missing')
+          end
+      end
+    end
   end
 
   describe '#update_incident' do


### PR DESCRIPTION
With current master, when HTTParty returns an error, an exception is thrown as `response=` doesn't exist.

Changed `attr_readers` to `attr_accessors` for `ResponseError`. Also cleaned up `#to_s` a little to show what we'd like to see while developing.

Added a test to check that error is working as expected.

Bumped version to prepare for release (fixes #5).